### PR TITLE
Grails 3 max release change

### DIFF
--- a/grails-3/Dockerfile
+++ b/grails-3/Dockerfile
@@ -2,8 +2,8 @@ FROM java:8
 MAINTAINER Manuel Ortiz Bey <ortiz.manuel@mozartanalytics.com>
 
 # Set customizable env vars defaults.
-# Set Grails version (default: 3.2.8; min: 3.0.0; max: 3.2.8).
-ENV GRAILS_VERSION 3.2.8
+# Set Grails version (default: 3.3.0; min: 3.0.0; max: 3.3.0).
+ENV GRAILS_VERSION 3.3.0
 
 # Install Grails
 WORKDIR /usr/lib/jvm


### PR DESCRIPTION
The max Grails 3 release upgrade from 3.2.8 to 3.3.0.